### PR TITLE
Removing last toDo in page QC

### DIFF
--- a/source/our_tools/other_pipelines.rst
+++ b/source/our_tools/other_pipelines.rst
@@ -44,7 +44,7 @@ To assess the quality of your bundles, the best way is to check the data visuall
 Tractometry
 -----------
 
-If you have a ground truth, you can compute statistics for each bundle using the tractometer. You can find the definition of each metric (ex., VB, IB, VC, IC, OL, OR) on the `tractometer website <http://tractometer.org/ismrm_2015_challenge/evaluation>`_.
+If you have a ground truth, you can compute statistics for each bundle using the metrics that were introduced in the tractometer. You can find the definition of each metric (ex., VB, IB, VC, IC, OL, OR) on the `tractometer website <http://tractometer.org/ismrm_2015_challenge/evaluation>`_. To compute them, you can use scilpy's script `scil_evaluate_bundles_pairwise_agreement_measures.py`.
 
 
 Sharing your work

--- a/source/our_tools/other_pipelines.rst
+++ b/source/our_tools/other_pipelines.rst
@@ -1,6 +1,6 @@
 .. _ref_other_pipelines:
 
-After tractoflow
+Checks and stats
 ================
 
 .. role:: bash(code)
@@ -9,10 +9,10 @@ After tractoflow
 Once the preprocessing and the tracking are done, scilpy also contains scripts to separate your data into known bundles (Recobundles), vizualize your results (ex, scil_visualize_bundles_mosaic.py), compute statistics on your bundles and so on.
 
 
-QA/ QC  (Quality assurance, Quality check)
-------------------------------------------
+QA/ QC  (Quality assurance, Quality check) -- tractoflow
+--------------------------------------------------------
 
-We have a QC pipeline which creates a summary of the quality of your data.
+We have a QC pipeline which creates a summary of the quality of your tractoflow results.
 
 *How to install it?*
 
@@ -34,25 +34,24 @@ This produces a QC report for each important section of the tractoflow. For inst
 
 We will soon add here a list of characteristic you should expect to see for each metric, to help beginners develop an expert eye when looking at processed data.
 
-*How to share my work?*
 
-If you have reached this point, congratulations! You have run tractoflow, which uses a significant amount of computation time, and you have verified your data, which required a significant amount of your time. It would be great to ensure that other lab members don't need to reproduces the same steps for the same data. If you believe your data should be shared to the rest of the lab:
+QA/ QC  (Quality assurance, Quality check) -- recobundlesX
+----------------------------------------------------------
 
-    1. Please ask at least one other person to double-check your QC. You can share your html files on our slack channel #HelpMeQcMyData.
+To assess the quality of your bundles, the best way is to check the data visually using the mosaic, as described on the RecobundlesX page. However if you possess the ground truth for your data, you may use tractometry for your statistics.
 
-    2. Plase talk with Arnaud. He will tell you the best way to include your processed data either to BrainData or to Beluga.
-
-RecobundlesX
-------------
-
-ToDO
-
-BundleReporting
----------------
-
-ToDo
 
 Tractometry
 -----------
 
-ToDo
+If you have a ground truth, you can compute statistics for each bundle using the tractometer. You can find the definition of each metric (ex., VB, IB, VC, IC, OL, OR) on the `tractometer website <http://tractometer.org/ismrm_2015_challenge/evaluation>`_.
+
+
+Sharing your work
+-----------------
+
+If you have reached this point, congratulations! You have run processes that use a significant amount of computation time, and you have verified your data, which required a significant amount of your time. It would be great to ensure that other lab members don't need to reproduces the same steps for the same data. If you believe your data should be shared to the rest of the lab:
+
+    1. Please ask at least one other person to double-check your QC. You can share your html files on our slack channel #HelpMeQcMyData.
+
+    2. Please talk with Arnaud. He will tell you the best way to include your processed data either to BrainData or to Beluga.


### PR DESCRIPTION

There were "ToDO"s left in the page "After tractoflow". 

--> RecobundlesX: the page is actually already created. So this page becomes "After tractoflow and recobundles"

--> BundleReporting: what did we mean by that? More than what I added?

-->Tractometry: I added a page to the ISMRM 2015 where at metrics are explained.