### PR TITLE
Add section for python installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 build
+_build
 source/_static
 source/_templates
+.vscode

--- a/source/index.rst
+++ b/source/index.rst
@@ -34,6 +34,7 @@ in the lab, from using Linux to developing code.
     tools/dipy
     tools/mi-brain
     tools/environments
+    tools/python
     tools/nextflow_singularity
     tools/ants
     tools/cbrain

--- a/source/our_tools/scilpy.rst
+++ b/source/our_tools/scilpy.rst
@@ -24,6 +24,9 @@ Finally, for a html version of the help, you will find the description of all sc
 
 
 Installing scilpy
+
+Scilpy currently supports python versions 3.6 to 3.8. There are many ways to install a python version on your system. We refer the reader to section :ref:`ref_python_dist` for one such method. Once your python distribution is correctly installed, Scilpy can be installed by following the procedure outlined below.
+
     - Users: you can follow the instructions on the Github page or follow these instructions :
 
     .. code-block:: bash

--- a/source/tools/python.rst
+++ b/source/tools/python.rst
@@ -1,0 +1,18 @@
+.. _ref_python_dist:
+
+
+Python distributions
+====================
+
+.. role:: bash(code)
+   :language: bash
+
+Although your Linux distribution most likely already includes a python distribution, it may be necessary to install additionnal python packages for software development. There are many alternatives for installing python. On Ubuntu, we can use the `deadsnakes <https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa>`_ repository to download and install a specific version:
+
+.. code-block:: bash
+
+        sudo add-apt-repository ppa:deadsnakes/ppa
+        sudo apt-get install python3.7-dev python3.7-venv python3.7-tk python3-pip  # python3.7 works well for scilpy
+        python3.7 -m pip install pip  # update pip (python package manager) to latest version
+
+Other python packages can be installed by replacing python3.X by a version of your choice.


### PR DESCRIPTION
To this date, I've shared a procedure for installing python on Ubuntu with Frédéric, Florence (last summer interns) and Erick and it helped all of them. I think it would make sense to add it to the documentation. The procedure is available [here](https://gist.github.com/CHrlS98/7ce4996d95247907124cc0f3a447401c) and used to act as an reminder for when I set myself up on a new desktop.

So, here is my attempt at adding the procedure to our website. Should we put it elsewhere? Do you want to add something?

Thanks!