### PR TITLE
Our team

### DIFF
--- a/source/arriving/our_team.rst
+++ b/source/arriving/our_team.rst
@@ -1,0 +1,56 @@
+
+Our team
+========
+
+Professors
+----------
+
+- `Maxime Descoteaux <https://www.usherbrooke.ca/informatique/nous-joindre/personnel/corps-professoral/professeurs/maxime-descoteaux>`_
+- `François Rheault <https://www.usherbrooke.ca/informatique/nous-joindre/personnel/corps-professoral/professeurs/francois-rheault>`_ (MINI-Lab, Sherbrooke University)
+
+Research assistants
+-------------------
+
+- Arnaud Boré
+- Gabriel Girard
+
+Post-docs
+---------
+
+- Manon Edde
+- Graham Little
+
+PhD students
+------------
+
+- `Emmanuelle Renauld <https://sites.google.com/site/renauldemmanuelle/home>`_
+- Charles Poirier
+- Alex Valcourt Caron
+- Antoine Théberge
+- Philippe Karan
+- Anthony Gagnon
+- Erick Hernandez Gutierrez
+
+Master students
+---------------
+
+- Antoine Royer
+
+
+Former students
+---------------
+
+- Jean-Christophe Houde
+- Michaël Paquette
+- Marc-Alexandre Côté
+- Samuel St-Jean
+- Maxime Chamberland
+- Gabriel Girard
+- François Rheault
+- Étienne St-Onge
+- Gabrielle Grenier
+- Philippe Poulin
+- Sami Obaid
+- Matteo Batocchio
+- Jon Haitz Legarreta Gorrono
+- Guillaume Theaud

--- a/source/arriving/our_team.rst
+++ b/source/arriving/our_team.rst
@@ -26,22 +26,47 @@ Our team
        | - Erick Hernandez Gutierrez
      - Antoine Royer
 
+
+Former students and more
+************************
+
 .. list-table::
-   :widths: 100
+   :widths: 33 33 33
    :header-rows: 1
 
    * - Former students
-   * - | - Jean-Christophe Houde
-       | - Michaël Paquette
-       | - Marc-Alexandre Côté
-       | - Samuel St-Jean
-       | - Maxime Chamberland
-       | - Gabriel Girard
-       | - François Rheault
-       | - Étienne St-Onge
-       | - Gabrielle Grenier
-       | - Philippe Poulin
+     - Former students (co-direction)
+     - Other
+   * - | - Marc-Alexandre Côté
+       | - Etienne Saint-Amant (master: 2011)
+       | - Michaël Bernier (master: 2012)
+       | - Arnaud Boré (master: 2012)
+       | - Caroline Presseau (master: 2014)
+       | - Samuel St-Jean (master: 2015)
+       | - Alexandre Gauvin (master: 2016)
+       | - Louis-Philippe Ledoux (master: 2017)
+       | - Gabriel Girard (master: 2013, PhD: 2016)
+       | - Maxime Chamberland (master: 2013, PhD: 2017)
+       | - Michaël Paquette (PhD: 2017)
+       | - François Rheault (PhD: 2020)
+       | - Étienne St-Onge (master: 2016, PhD: 2020)
+       | - Ann-Marie Beaudoin (master: 2021)
+       | - Anthony Gagnon (master: 2022)
+       | - Gabrielle Grenier (master: 2022)
+       | - Philippe Poulin (PhD: 2022)
+       | - Jasmeen Sidhu (PhD: 2022)
+       | - Guillaume Theaud (PhD: 2022)
+       | - Jon Haitz Legarreta Gorrono (PhD: 2023)
        | - Sami Obaid
-       | - Matteo Batocchio
-       | - Jon Haitz Legarreta Gorrono
-       | - Guillaume Theaud
+       | - Emmanuelle Renauld (master: 2015, PhD: ongoing)
+       | - Philippe Karan (master: 2021, PhD: ongoing)
+       | - Antoine Théberge (master: 2021, PhD: ongoing)
+       | - Alex Valcourt Caron (master: 2022, PhD: ongoing)
+       | - Charles Poirier (master: 2023, PhD: ongoing)
+     - | - Vincent Méthot (master: 2016)
+       | - Marc-Alexandre Côté (master: 2012, PhD: 2017)
+       | - Alexandre Bizeau (master: 2017)
+       | - Matteo Batocchio (PhD: 2022)
+       | - Jérémie Fouquet ( )
+       | - Martin Cousineau (master: 2017)
+     - | - Jean-Christophe Houde

--- a/source/arriving/our_team.rst
+++ b/source/arriving/our_team.rst
@@ -2,55 +2,46 @@
 Our team
 ========
 
-Professors
-----------
+.. list-table::
+   :widths: 20 20 20 20 20
+   :header-rows: 1
 
-- `Maxime Descoteaux <https://www.usherbrooke.ca/informatique/nous-joindre/personnel/corps-professoral/professeurs/maxime-descoteaux>`_
-- `François Rheault <https://www.usherbrooke.ca/informatique/nous-joindre/personnel/corps-professoral/professeurs/francois-rheault>`_ (MINI-Lab, Sherbrooke University)
+   * - Professors
+     - Research assistants
+     - Post-docs
+     - PhD students
+     - Master students
+   * - | - `Maxime Descoteaux <https://www.usherbrooke.ca/informatique/nous-joindre/personnel/corps-professoral/professeurs/maxime-descoteaux>`_
+       | - `François Rheault <https://www.usherbrooke.ca/informatique/nous-joindre/personnel/corps-professoral/professeurs/francois-rheault>`_ (MINI-Lab, Sherbrooke University)
+     - | - Arnaud Boré
+       | - Gabriel Girard
+     - | Manon Edde
+       | Graham Little
+     - | - `Emmanuelle Renauld <https://sites.google.com/site/renauldemmanuelle/home>`_
+       | - Charles Poirier
+       | - Alex Valcourt Caron
+       | - Antoine Théberge
+       | - Philippe Karan
+       | - Anthony Gagnon
+       | - Erick Hernandez Gutierrez
+     - Antoine Royer
 
-Research assistants
--------------------
+.. list-table::
+   :widths: 100
+   :header-rows: 1
 
-- Arnaud Boré
-- Gabriel Girard
-
-Post-docs
----------
-
-- Manon Edde
-- Graham Little
-
-PhD students
-------------
-
-- `Emmanuelle Renauld <https://sites.google.com/site/renauldemmanuelle/home>`_
-- Charles Poirier
-- Alex Valcourt Caron
-- Antoine Théberge
-- Philippe Karan
-- Anthony Gagnon
-- Erick Hernandez Gutierrez
-
-Master students
----------------
-
-- Antoine Royer
-
-
-Former students
----------------
-
-- Jean-Christophe Houde
-- Michaël Paquette
-- Marc-Alexandre Côté
-- Samuel St-Jean
-- Maxime Chamberland
-- Gabriel Girard
-- François Rheault
-- Étienne St-Onge
-- Gabrielle Grenier
-- Philippe Poulin
-- Sami Obaid
-- Matteo Batocchio
-- Jon Haitz Legarreta Gorrono
-- Guillaume Theaud
+   * - Former students
+   * - | - Jean-Christophe Houde
+       | - Michaël Paquette
+       | - Marc-Alexandre Côté
+       | - Samuel St-Jean
+       | - Maxime Chamberland
+       | - Gabriel Girard
+       | - François Rheault
+       | - Étienne St-Onge
+       | - Gabrielle Grenier
+       | - Philippe Poulin
+       | - Sami Obaid
+       | - Matteo Batocchio
+       | - Jon Haitz Legarreta Gorrono
+       | - Guillaume Theaud

--- a/source/arriving/our_team.rst
+++ b/source/arriving/our_team.rst
@@ -17,7 +17,7 @@ Our team
        | - Gabriel Girard
      - | Manon Edde
        | Graham Little
-     - | - `Emmanuelle Renauld <https://sites.google.com/site/renauldemmanuelle/home>`_
+     - | - Emmanuelle Renauld
        | - Charles Poirier
        | - Alex Valcourt Caron
        | - Antoine Théberge

--- a/source/arriving/welcome.rst
+++ b/source/arriving/welcome.rst
@@ -5,7 +5,7 @@ Onboarding new students
 
 Important rooms and places
 """"""""""""""""""""""""""
-Chantal Proulx, Lynn Lebrun, Marie-Pier Côté and generally the Faculty’s offices are important and you should know where they are. Ask someone in the lab or Maxime to guide you.
+Chantal Proulx, Marie-Pier Côté and generally the `Faculty’s offices <https://www.usherbrooke.ca/informatique/nous-joindre/personnel>`_ are important and you should know where they are. Ask someone in the lab or Maxime to guide you.
 
 Subscriptions
 """""""""""""
@@ -15,11 +15,11 @@ Don't hesitate to remind Maxime or his research assistants if some of the follow
 Keys to the lab
     Maxime will ask them for you. You should receive an email.
 
-Google Calendar
+Google Calendar + Teams Calendar
     Maxime will add you to the lab calendar. We note our lab meetings, events and other important information and we use it everyday, so you should make a habit of following it! Maxime can also add you to his personal calendar so you can follow his availabilities.  * Tip. It's easier if you have a gmail account.
 
 Mailing list
-    When Maxime wants to send a message to everyone, we either use Slack or our mailing list. Ask Maxime to add you.
+    When Maxime wants to send a message to everyone, we either use Teams or our mailing list. Ask Maxime to add you.
 
 Teams
     We use Microsoft Teams as means of communication. You can use your CIP and university's password to connect. You can ask Maxime to add you to the SCIL's "team". Then, you can explore the various conversations, called "channels". When lab meetings are online, you can join them via the "General" channel. Also, we encourage you to explore the videos in the video tab from the General channel. You can find there the recording of previous lab meetings, videos of Max's dMRI class and more.

--- a/source/index.rst
+++ b/source/index.rst
@@ -6,15 +6,13 @@
 Welcome to the SCIL lab documentation!
 =============================================
 
-Our lab works in diffusion MRI. You can visit our official website for more information on Maxime Descoteaux, the director, and
-on the students in the lab, for a list of our publications, and more. http://scil.usherbrooke.ca/en/
+Our lab works in diffusion MRI, from the acquisition sequences and local reconstruction to tractography and its usages in applied contexts, including tractometry.
 
 .. image:: ./images/scil_unique_2019.jpg
     :scale: 10 %
     :align: center
 
-Here, you will find a summary of the tools we develop, and some clues on how we do things
-in the lab, from using Linux to developing code.
+Here, you will find a summary of the tools we develop, and some clues on how we do things in the lab, from using Linux to developing code.
 
 .. toctree::
     :maxdepth: 1
@@ -26,7 +24,7 @@ in the lab, from using Linux to developing code.
 
 .. toctree::
     :maxdepth: 1
-    :caption: Intro to CS
+    :caption: Intro to Computer Science
 
     intro_to/explore_os
     intro_to/explore_python

--- a/source/index.rst
+++ b/source/index.rst
@@ -22,6 +22,7 @@ in the lab, from using Linux to developing code.
 
     arriving/welcome
     arriving/useful_links
+    arriving/our_team
 
 .. toctree::
     :maxdepth: 1


### PR DESCRIPTION
- Maxime's scil webpage does not include the list of students anymore. Adding here.
- Maxime's scil "Publication" page has not been updated since 2017. Removing the "look on our official page for all information" sentence.
- Remove Lynn Lebrun


Our Team page: There are probably people missing! To be updated. We can then tell everyone to do a pull request if they want to add a link to their own pages.