### PR TITLE
Corections and minor modifications of the scil doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,12 @@
 Here is the link to our web site: https://scil-documentation.readthedocs.io/
 
 
-*Note for developers: To test your changes, you can build the website locally with:
+*Note for developers: To test your changes, first install sphinx-rtd-theme with:
+
+    sudo apt-get install python3-sphinx
+    pip install sphinx-rtd-theme
+
+And build the website locally with:
 
     make html
 

--- a/source/arriving/our_team.rst
+++ b/source/arriving/our_team.rst
@@ -24,6 +24,7 @@ Our team
        | - Philippe Karan
        | - Anthony Gagnon
        | - Erick Hernandez Gutierrez
+       | - Stanislas Thoumyre
      - Antoine Royer
 
 

--- a/source/intro_to/explore_os.rst
+++ b/source/intro_to/explore_os.rst
@@ -299,23 +299,25 @@ Bash environment
 When a program is invoked it is given an array of strings called the environment. This is a list of name-value pairs, of the form name=value.
 
 You can view all environment variables set on your system with the env command. The list is long, so pipe the output through more to make it easier to read:
+
 .. code-block:: bash
 
     env | more
 
 Environment variables can be useful when you want to override default settings, or when you need to manage new settings.
 
-when you type a command, the only reason your computer knows how to find the application corresponding to that command is that the PATH environment variable tells it where to look. 
+When you type a command, the only reason your computer knows how to find the application corresponding to that command is that the PATH environment variable tells it where to look. 
 
 You can add a location to your path the way you create throw-away variables. It works, but only as long as the shell you used to modify your system path remains open.
+
 .. code-block:: bash
 
-    # modify your system path:modify an environment variable
+    # Modify your system path:modify an environment variable
     export PATH=$PATH:/home/seth/bin
 
 .. code-block:: bash
 
-    # show your new path:
+    # Show your new path:
     echo $PATH
 
 Then close your session and open a new one. You'll see that the PATH has returned to its default state.
@@ -329,11 +331,12 @@ To edit your .bashrc file use a command line editor like vim or nano:
     vim ~/.bashrc
     nano ~/.bashrc
 
-From your .bashrc you can modify your part default environment by adding lines to it. This includes loading modules, modifying environment variables, and activating Python virtual environments.
+From your .bashrc you can modify your part default environment by adding lines to it. This includes defining alias, modifying environment variables, and activating Python virtual environments.
+
 .. code-block:: bash
 
-    # to load a module:
-    module load <module>
+    # To define an alias:
+    alias ..='cd ..'
 
 .. code-block:: bash
 

--- a/source/intro_to/explore_os.rst
+++ b/source/intro_to/explore_os.rst
@@ -292,3 +292,57 @@ These are examples of what can be done in bash in short one-line, but to get the
 7. Using sed and a regular expression to remove lines containing a specific pattern from a file:
     :bash:`sed -i '/patternToRemove/d' file.txt`
     This command will remove all lines from the file "file.txt" that contain the pattern "patternToRemove".
+
+Bash environment
+----------------
+
+When a program is invoked it is given an array of strings called the environment. This is a list of name-value pairs, of the form name=value.
+
+You can view all environment variables set on your system with the env command. The list is long, so pipe the output through more to make it easier to read:
+.. code-block:: bash
+
+    env | more
+
+Environment variables can be useful when you want to override default settings, or when you need to manage new settings.
+
+when you type a command, the only reason your computer knows how to find the application corresponding to that command is that the PATH environment variable tells it where to look. 
+
+You can add a location to your path the way you create throw-away variables. It works, but only as long as the shell you used to modify your system path remains open.
+.. code-block:: bash
+
+    # modify your system path:modify an environment variable
+    export PATH=$PATH:/home/seth/bin
+
+.. code-block:: bash
+
+    # show your new path:
+    echo $PATH
+
+Then close your session and open a new one. You'll see that the PATH has returned to its default state.
+
+You can set your own persistent environment variables in your shell configuration file, which is ~/.bashrc.
+
+To edit your .bashrc file use a command line editor like vim or nano:
+
+.. code-block:: bash
+
+    vim ~/.bashrc
+    nano ~/.bashrc
+
+From your .bashrc you can modify your part default environment by adding lines to it. This includes loading modules, modifying environment variables, and activating Python virtual environments.
+.. code-block:: bash
+
+    # to load a module:
+    module load <module>
+
+.. code-block:: bash
+
+    # To modify an environment variable:
+    export PATH=$PATH:<path/to/dir>
+
+.. code-block:: bash
+
+    # To activate a Python environment:
+    source <path/to/env>/bin/activate
+
+    

--- a/source/intro_to/explore_software.rst
+++ b/source/intro_to/explore_software.rst
@@ -175,7 +175,7 @@ Installation
 
 We recommand building MRtrix from source if you are on Linux `(here) <https://mrtrix.readthedocs.io/en/latest/installation/build_from_source.html>`__. If you are on MacOS you can use :bash:`brew install mrtrix3`.
 
-Be sure to install all dependencies, then follow all the installation step up to *Set up MRtrix3* or add this line you your :bash:`.bashrc`: :bash:`export PATH=~/PATH/TO/MRTRIX3/mrtrix3/bin:${PATH}`
+Be sure to install all dependencies, then follow all the installation step up to *Set up MRtrix3* or add this line to your :bash:`.bashrc`: :bash:`export PATH=~/PATH/TO/MRTRIX3/mrtrix3/bin:${PATH}`
 
 Once installed, you should be able to type :bash:`dwi2fod` to see the help display or :bash:`mrview` to launch the GUI.
 

--- a/source/intro_to/explore_virtual_machines.rst
+++ b/source/intro_to/explore_virtual_machines.rst
@@ -53,9 +53,10 @@ Installations
 
 *Do not try to install on MacOS*
 
-The documentation to install Singularity is easy enough to follow `(here) <https://docs.sylabs.io/guides/3.0/user-guide/installation.html>`__.
+The easiest way to install a container it's by Apptainer `(here) <https://apptainer.org/docs/admin/main/installation.html#install-ubuntu-packages>`__.
 
-However, make sure you follow these subsections:
+Otherwise, the documentation to install Singularity is easy enough to follow `(here) <https://docs.sylabs.io/guides/3.0/user-guide/installation.html>`__.
+However, for Singularity, make sure you follow these subsections:
     - Install Dependencies (:bash:`sudo apt install` for Ubuntu)
     - Install Go (change :bash:`export VERSION=1.11` to :bash:`export VERSION=1.13`)
     - Download and install Singularity from a release (change :bash:`export VERSION=3.0.3` to :bash:`export VERSION=3.7.4`)
@@ -85,7 +86,7 @@ Installations
 
 It is always important to verify if a software is already installed before installing it, but it is **really** important with Docker.
 
-The documentation to install Singularity is easy enough to follow `(here) <https://docs.docker.com/engine/install/ubuntu>`__.
+The documentation to install Docker is easy enough to follow `(here) <https://docs.docker.com/engine/install/ubuntu>`__.
 
 However, make sure you follow these subsections:
     - Uninstall old versions (sometimes `this <https://askubuntu.com/questions/935569/how-to-completely-uninstall-docker>`__ is necessary, answer #1)

--- a/source/other/conferences.rst
+++ b/source/other/conferences.rst
@@ -21,13 +21,14 @@ Summary, coming events and deadlines
 
     - **June 23-27: OHBM**, Korea: https://www.humanbrainmapping.org/i4a/pages/index.cfm?pageid=3298
 
-        - Dates to be announced
+        - Dec 1: Abstract submission
 
-    - **July 3-5: MIDL**, Paris: https://2023.midl.io/
+    - **July 3-5: MIDL**, Paris: https://2024.midl.io/
 
-        - Dates to be announced
+        - Feb 7: Full paper submission
+        - Apr 10: Short paper submission
 
-    - | **Oct 6-10: MICCAI**, Morocco http://www.miccai.org/news/2020/12/31/and-the-location-of-miccai-2024-is
+    - | **Oct 6-10: MICCAI**, Morocco https://conferences.miccai.org/2024/en/
 
         - Dates to be announced
 

--- a/source/our_tools/recobundles.rst
+++ b/source/our_tools/recobundles.rst
@@ -2,7 +2,7 @@ RecobundlesX
 ============
 
 Recobundles is a tool to separate your wholebrain tracking result into different bundles divided into separate files. Dipy has a published version, called Recobundles. It is single atlas and single parameter while our version (which we call RecobundlesX) is multi-atlas and multi-parameter, and shown to be more robust in Rheault 2020 (PhD thesis, chapter 4, https://savoirs.usherbrooke.ca/handle/11143/17255).
-An atlas is available `on zenodo <https://zenodo.org/record/5165374#.YlcGUXXMKiM/>`_ (models, config and reference).
+An atlas is available `on zenodo <https://zenodo.org/records/7950602>`_ (models, config and reference).
 There is a Nextflow pipeline for this tool, available `on Github <https://github.com/scilus/rbx_flow/>`_
 
 


### PR DESCRIPTION
I have made some changes to scil-documentation : 
- README : add the installation of sphinx-rtd-theme necessary to make the html
- add my name to the list of PhD student
- add link to install Apptainer
- creation of a section on the bash environment, as the 'export' command is never really explained in the docs
- correction of a few typos
- update of the various conferences
- updated zenodo link 