### PR TITLE
fix typo in flows sections

### DIFF
--- a/source/our_tools/flows.rst
+++ b/source/our_tools/flows.rst
@@ -145,7 +145,7 @@ For that, RBx_flow use two files: the local tracking file and the fractional ani
 
     .. code-block:: bash
 
-        nextflow ${FLOW_DIR}/rbx_flow/main.nf --input RBx_flow_tmake htmlest/raw --atlas_directory atlas \
+        nextflow ${FLOW_DIR}/rbx_flow/main.nf --input RBx_flow_test/raw --atlas_directory atlas \
          -with-singularity ./containers_scilus_1.6.0.sif -w RBx_flow_test/work -resume
 
 Parameters:


### PR DESCRIPTION
There's a typo in one of the commands in the flows section.