### PR TITLE
small fix nf run hello

### DIFF
--- a/source/arriving/setup_computer.rst
+++ b/source/arriving/setup_computer.rst
@@ -244,7 +244,7 @@ Now you can install Nextflow by opening a terminal and executing the following l
     source ~/.bashrc
 
     # Test Nextflow
-    nextflow run hello
+    nextflow run hello -dsl2
 
 .. _ref_highperfcomputer:
 


### PR DESCRIPTION
The script .nextflow/assets/nextflow-io/hello/main.nf uses DSL2, which requires enabling DSL2 explicitly when running with Nextflow version 21.12.1-edge. Without the -dsl2 flag, Nextflow throws the following error:
![image](https://github.com/user-attachments/assets/bd33574d-93fb-4d69-9134-7e49c211ba5c)
